### PR TITLE
make compatible with X and Y chromosomes

### DIFF
--- a/conf/eddie.config
+++ b/conf/eddie.config
@@ -20,7 +20,7 @@ process {
   beforeScript =
   """
   . /etc/profile.d/modules.sh
-  module load 'singularity'
+  module load igmm/apps/singularity/3.8.7
   unset XDG_RUNTIME_DIR
   export SINGULARITY_TMPDIR="\$TMPDIR"
   """

--- a/modules/ldblocks.nf
+++ b/modules/ldblocks.nf
@@ -1,5 +1,6 @@
 process pull_ld {
     label 'qctool_image'
+    label 'bigmem'
 
     input:
     tuple val(RSID), val(CHR), val(POS), val(PREFIX), path(BGEN_FILES)

--- a/modules/ldblocks.nf
+++ b/modules/ldblocks.nf
@@ -2,7 +2,7 @@ process pull_ld {
     label 'qctool_image'
 
     input:
-    tuple val(CHR), val(RSID), val(POS), val(PREFIX), path(BGEN_FILES)
+    tuple val(RSID), val(CHR), val(POS), val(PREFIX), path(BGEN_FILES)
 
     output:
     tuple val(RSID), val(CHR), val(POS), path("*.sqlite")

--- a/subworkflows/ldblocks.nf
+++ b/subworkflows/ldblocks.nf
@@ -24,7 +24,10 @@ workflow ImportSNPs {
             }
             .set {bgen_ch}
 
-        snps_bgen_ch = snps_ch.join(bgen_ch)
+        // add proper chromosome BGEN files into SNP channel
+        snps_bgen_ch = snps_ch.combine(bgen_ch)
+            .filter { it -> it[0] == it[3] }
+            .map { chr, snp, pos, _chr2, prefix, files -> [snp, chr, pos, prefix, files]}
         
     emit:
         snps_bgen_ch
@@ -36,6 +39,7 @@ workflow ComputeLD {
 
     main:
         ld_ch = pull_ld(snps_bgen)
+
         // filter for just sqlite files and collect
         ld_ch.map{ _snp, _chr, _pos, sqlite_files -> sqlite_files }
             .collect()

--- a/subworkflows/ldblocks.nf
+++ b/subworkflows/ldblocks.nf
@@ -14,7 +14,7 @@ workflow ImportSNPs {
         
         bgen_files
             .map { prefix, files ->
-                def match = prefix =~ /(\d+)$/
+                def match = prefix =~ /(\d+|X|Y)$/
                 def chr = match ? match.group(1) : null
                 if (chr == null) {
                     println "Warning: Could not extract chromosome number from ${prefix}"
@@ -37,7 +37,7 @@ workflow ComputeLD {
     main:
         ld_ch = pull_ld(snps_bgen)
         // filter for just sqlite files and collect
-        ld_ch.map{ snp, chr, pos, sqlite_files -> sqlite_files }
+        ld_ch.map{ _snp, _chr, _pos, sqlite_files -> sqlite_files }
             .collect()
             .set { sqlite_ch }
 

--- a/test.config
+++ b/test.config
@@ -1,9 +1,0 @@
-params {
-    COHORT = "GENOMICC"
-    INPUT_SNPS = "${launchDir}/input/test.csv"
-    BGEN_FILES = "/exports/igmm/eddie/ponting-lab/breeshey/data/genomicc/imputed/genomic-isaric/GenOMICC_ISARIC_chr*.{bgen,sample,bgen.bgi}"
-    BED_FILES = "/exports/igmm/eddie/ponting-lab/breeshey/data/genomicc/geno_byChr/wp5-gwas-r9-genomicc-isaric4c-nodupl-phenoind_chr*.{bed,bim,fam}"
-    TRAITS_DATASET = "/exports/igmm/eddie/ponting-lab/breeshey/data/genomicc/pheno/genomicc.allcohorts.pheno.withdate.withcovariates.withconfounders.filt.csv"
-    FLASHPCA_EXCLUSION_REGIONS = "${projectDir}/assets/exclusion_regions_hg38.txt"
-    NB_PCS = 5
-}


### PR DESCRIPTION
Currently, this pipeline is only set up for numeric chromosomes 1-22. This PR includes updating the REGEX for splitting BGEN files out by chromosome.

This also includes a bug fix where, when joining the snps and bgen channels together, only 1 SNP per-chromosome was kept. Now this code has been updated to include all SNPs.